### PR TITLE
Add a ScrapedPage::Response#url method

### DIFF
--- a/lib/scraped_page/response.rb
+++ b/lib/scraped_page/response.rb
@@ -1,11 +1,12 @@
 class ScrapedPage
   class Response
-    attr_reader :status, :headers, :body
+    attr_reader :status, :headers, :body, :url
 
-    def initialize(body:, status: 200, headers: {})
+    def initialize(body:, url:, status: 200, headers: {})
       @status = status
       @headers = headers
       @body = body
+      @url = url
     end
   end
 end


### PR DESCRIPTION
This means that the response contains the url that it was obtained from,
which is going to be required when we change the `ScrapedPage`
subclasses so they only know about responses.

Fixes #18 