### PR TITLE
Add support for noko fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,36 @@ page.to_h
 # => { :title => "Example Domain", :more_information => "http://www.iana.org/domains/reserved" }
 ```
 
+### Dealing with sections of a page
+
+When writing an HTML scraper you'll often need to deal with just a part of the page.
+For example you might want to scrape a table containing a list of people and some
+associated data.
+
+To do this you can pass a `noko` keyword argument to a `Scraped::HTML` subclass
+constructor. This will then replace the `noko` Nokogiri instance in the scraper
+with the one you specify.
+
+```ruby
+class MemberRow < Scraped::HTML
+  field :name do
+    noko.css('td.full-name')
+  end
+end
+
+class MembersTable < Scraped::HTML
+  field :members do
+    noko.css('tr').map { |row| MemberRow.new(response: response, noko: row) }
+  end
+end
+
+class AllMembersPage < Scraped::HTML
+  field :members_term_10_table do
+    MembersTable.new(response: response, noko: noko.css('table.members-list-term-10')
+  end
+end
+```
+
 ## Extending
 
 There are two main ways to extend `scraped` with your own custom logic - custom requests and decorated responses. Custom requests allow you to change where the scraper is getting its responses from, e.g. you might want to make requests to archive.org if the site you're scraping has disappeared. Decorated responses allow you to manipulate the response before it's passed to the scraper. For example you might want to make all the links on the page absolute rather than relative.

--- a/README.md
+++ b/README.md
@@ -69,19 +69,19 @@ with the one you specify.
 ```ruby
 class MemberRow < Scraped::HTML
   field :name do
-    noko.css('td.full-name')
+    noko.css('td')[2].text
   end
-end
 
-class MembersTable < Scraped::HTML
-  field :members do
-    noko.css('tr').map { |row| MemberRow.new(response: response, noko: row) }
+  field :party do
+    noko.css('td')[3].text
   end
 end
 
 class AllMembersPage < Scraped::HTML
-  field :members_term_10_table do
-    MembersTable.new(response: response, noko: noko.css('table.members-list-term-10')
+  field :members do
+    noko.css('table.members-list tr').map do |row|
+      MemberRow.new(response: response, noko: row)
+    end
   end
 end
 ```

--- a/lib/scraped/html.rb
+++ b/lib/scraped/html.rb
@@ -2,6 +2,11 @@ class Scraped
   class HTML < Scraped
     private
 
+    def initialize(noko: nil, **args)
+      super(**args)
+      @noko = noko
+    end
+
     def noko
       @noko ||= Nokogiri::HTML(response.body)
     end

--- a/test/scraped/html_test.rb
+++ b/test/scraped/html_test.rb
@@ -18,5 +18,17 @@ describe Scraped::HTML do
     it 'returns the expected content' do
       ExamplePage.new(response: response).content.must_equal 'Hi there!'
     end
+
+    describe 'with a custom noko instance' do
+      let(:fragment) do
+        Nokogiri::HTML.fragment('<p class="test-content">Replacement</p>')
+      end
+
+      let(:page) { ExamplePage.new(response: response, noko: fragment) }
+
+      it 'returns the replacement content' do
+        page.content.must_equal 'Replacement'
+      end
+    end
   end
 end

--- a/test/scraped/html_test.rb
+++ b/test/scraped/html_test.rb
@@ -15,8 +15,10 @@ describe Scraped::HTML do
       end
     end
 
+    let(:page) { ExamplePage.new(response: response) }
+
     it 'returns the expected content' do
-      ExamplePage.new(response: response).content.must_equal 'Hi there!'
+      page.content.must_equal 'Hi there!'
     end
 
     describe 'with a custom noko instance' do


### PR DESCRIPTION
This allows an optional `noko` parameter to `ScrapedPage` constructors, which when given will override the `noko` scope for the current instance.

```ruby
MemberRow.new(response: response, noko: noko.css('.member-row'))
```

Then in the `MemberRow` `noko` would refer to the `.member-row` element, rather than the whole page, but it would still have access to the full response.

# Related issues

I think this should close #4, because then we can just use `ScrapedPage` subclasses everywhere and just pass an extra `noko` param

# Notes to merger

- [x] This needs to have it's base changed to `master` once #21 is merged.