### PR TITLE
Rename the library to Scraped

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in scraped_page.gemspec
+# Specify your gem's dependencies in scraped.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ScrapedPage
+# Scraped
 
 Write declarative scrapers in Ruby
 
@@ -7,7 +7,7 @@ Write declarative scrapers in Ruby
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'scraped_page'
+gem 'scraped'
 ```
 
 And then execute:
@@ -16,20 +16,20 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install scraped_page
+    $ gem install scraped
 
 ## Usage
 
-Create a subclass of `ScrapedPage` for each _type_ of page you wish to scrape.
+Create a subclass of `Scraped` for each _type_ of page you wish to scrape.
 
 For example if you were scraping a list of people you might have a
 `PeopleListPage` class for the list page and a `PersonPage` class for an
 individual person's page.
 
 ```ruby
-require 'scraped_page'
+require 'scraped'
 
-class ExamplePage < ScrapedPage
+class ExamplePage < Scraped
   field :title do
     noko.at_css('h1').text
   end
@@ -57,10 +57,10 @@ page.to_h
 
 ## Archiving scraped pages
 
-The default strategy for retrieving pages is `ScrapedPage::Strategy::LiveRequest`. If you'd also like to archive a copy of the page you're scraping into a git branch, you can pass a `:strategy` option to the constructor:
+The default strategy for retrieving pages is `Scraped::Strategy::LiveRequest`. If you'd also like to archive a copy of the page you're scraping into a git branch, you can pass a `:strategy` option to the constructor:
 
 ```ruby
-ExamplePage.new(url: 'http://example.com', strategy: ScrapedPage::Strategy::LiveRequestArchive.new)
+ExamplePage.new(url: 'http://example.com', strategy: Scraped::Strategy::LiveRequestArchive.new)
 ```
 
 This will use the [`scraped_page_archive`](https://github.com/everypolitician/scraped_page_archive)
@@ -82,7 +82,7 @@ class FilesystemStrategy
 end
 ```
 
-Then you can pass that strategy when creating an instance of your `ScrapedPage` subclass:
+Then you can pass that strategy when creating an instance of your `Scraped` subclass:
 
 ```ruby
 ExamplePage.new(url: 'http://example.com', strategy: FilesystemStrategy.new)
@@ -96,7 +96,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/everypolitician/scraped_page.
+Bug reports and pull requests are welcome on GitHub at https://github.com/everypolitician/scraped.
 
 ## License
 

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
-require 'scraped_page'
+require 'scraped'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/scraped.rb
+++ b/lib/scraped.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
-require 'scraped_page/version'
-require 'scraped_page/strategy/live_request'
-require 'scraped_page/strategy/live_request_archive'
-require 'scraped_page/response'
+require 'scraped/version'
+require 'scraped/strategy/live_request'
+require 'scraped/strategy/live_request_archive'
+require 'scraped/response'
 require 'nokogiri'
 require 'field_serializer'
 
 # Abstract class which scrapers can extend to implement their functionality.
-class ScrapedPage
+class Scraped
   include FieldSerializer
 
   def initialize(url:, strategy: Strategy::LiveRequest.new)

--- a/lib/scraped/response.rb
+++ b/lib/scraped/response.rb
@@ -1,4 +1,4 @@
-class ScrapedPage
+class Scraped
   class Response
     attr_reader :status, :headers, :body, :url
 

--- a/lib/scraped/strategy/live_request.rb
+++ b/lib/scraped/strategy/live_request.rb
@@ -1,6 +1,6 @@
 require 'open-uri'
 
-class ScrapedPage
+class Scraped
   module Strategy
     class LiveRequest
       def response(url)

--- a/lib/scraped/strategy/live_request_archive.rb
+++ b/lib/scraped/strategy/live_request_archive.rb
@@ -1,7 +1,7 @@
-require 'scraped_page/strategy/live_request'
+require 'scraped/strategy/live_request'
 require 'scraped_page_archive'
 
-class ScrapedPage
+class Scraped
   module Strategy
     class LiveRequestArchive < LiveRequest
       def response(url)

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
-class ScrapedPage
+class Scraped
   VERSION = '0.1.0'.freeze
 end

--- a/scraped.gemspec
+++ b/scraped.gemspec
@@ -1,16 +1,16 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'scraped_page/version'
+require 'scraped/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'scraped_page'
-  spec.version       = ScrapedPage::VERSION
+  spec.name          = 'scraped'
+  spec.version       = Scraped::VERSION
   spec.authors       = ['EveryPolitician']
   spec.email         = ['team@everypolitician.org']
 
   spec.summary       = 'Write declarative scrapers in Ruby'
-  spec.homepage      = 'https://github.com/everypolitician/scraped_page'
+  spec.homepage      = 'https://github.com/everypolitician/scraped'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/test/scraped_test.rb
+++ b/test/scraped_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
-describe ScrapedPage do
+describe Scraped do
   it 'has a version number' do
-    ::ScrapedPage::VERSION.wont_be_nil
+    ::Scraped::VERSION.wont_be_nil
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'scraped_page'
+require 'scraped'
 
 require 'minitest/autorun'


### PR DESCRIPTION
This should avoid some of the confusion that arose from the library
being called “ScrapedPage”. It was misleading having “page” in the name
because it gave unnecessary weight to the individual pages, when
actually the tools are for scraping whole sites.

This new name means we can have classes like `Scraped::HTML`, which
make more sense for both whole pages and fragments/sections of the page.

It also has the bonus of being able to say “have you Scraped that site”
:)

# Notes to merger

- After this has been merged the repo should be renamed to `scraped` on Github to reflect the change.