### PR TITLE
Move HTML specific parts into Scraped::HTML class

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Or install it yourself as:
 
 ## Usage
 
-Create a subclass of `Scraped` for each _type_ of page you wish to scrape.
+To write a standard HTML scraper, start by creating a subclass of
+`Scraped::HTML` for each _type_ of page you wish to scrape.
 
 For example if you were scraping a list of people you might have a
 `PeopleListPage` class for the list page and a `PersonPage` class for an
@@ -29,7 +30,7 @@ individual person's page.
 ```ruby
 require 'scraped'
 
-class ExamplePage < Scraped
+class ExamplePage < Scraped::HTML
   field :title do
     noko.at_css('h1').text
   end

--- a/lib/scraped.rb
+++ b/lib/scraped.rb
@@ -19,8 +19,4 @@ class Scraped
   def url
     response.url
   end
-
-  def noko
-    @noko ||= Nokogiri::HTML(response.body)
-  end
 end

--- a/lib/scraped/html.rb
+++ b/lib/scraped/html.rb
@@ -1,0 +1,7 @@
+class Scraped
+  class HTML < Scraped
+    def noko
+      @noko ||= Nokogiri::HTML(response.body)
+    end
+  end
+end

--- a/lib/scraped/html.rb
+++ b/lib/scraped/html.rb
@@ -1,5 +1,7 @@
 class Scraped
   class HTML < Scraped
+    private
+
     def noko
       @noko ||= Nokogiri::HTML(response.body)
     end

--- a/test/scraped/html_test.rb
+++ b/test/scraped/html_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+describe Scraped::HTML do
+  describe 'accessing HTML via nokogiri' do
+    let(:response) do
+      Scraped::Response.new(
+        body: '<p class="test-content">Hi there!</p>',
+        url:  'http://example.com'
+      )
+    end
+
+    class ExamplePage < Scraped::HTML
+      field :content do
+        noko.css('.test-content').text
+      end
+    end
+
+    it 'returns the expected content' do
+      ExamplePage.new(response: response).content.must_equal 'Hi there!'
+    end
+  end
+end


### PR DESCRIPTION
In the future we expect to have classes for scraping other content types, so we don't want the root class to have logic for specific content types in it.

Fixes #17 