### PR TITLE
Fix README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ class CustomHeader < Scraped::Response::Decorator
   end
 end
 
-response = Scraped::Request.new(url: url).response([
+response = Scraped::Request.new(url: url).response(decorators: [
   { decorator: CustomHeader, greeting: 'Hello, world' }
 ])
 ```


### PR DESCRIPTION
This was still using the positional parameters, but we actually ended up
going with keyword arguments, so update the example to reflect that.