### PR TITLE
Add response decorators to Scraped subclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ end
 
 With the above code a custom header would be added to the response: `X-Greeting: Hello, world`.
 
+#### Inheritance with decorators
+
+When you inherit from a class that already has decorators the child class will also inherit the parent's decorators. There's currently no way to re-order or remove decorators in child classes, though that _may_ be added in the future.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ end
 
 As well as the `body` method you can also supply your own `url`, `status` and `headers` methods. You can access the current request body by calling `super` from your method. You can also call `url`, `headers` or `status` to access those properties of the current response.
 
-To use a response decorator you need to use the `decorators` class method in a `Scraped::HTML` subclass:
+To use a response decorator you need to use the `decorator` class method in a `Scraped::HTML` subclass:
 
 ```ruby
 class PageWithRelativeLinks < Scraped::HTML
-  decorators [AbsoluteLinks]
+  decorator AbsoluteLinks
 
   # Other fields...
 end
@@ -157,7 +157,7 @@ class CustomHeader < Scraped::Response::Decorator
 end
 
 class ExamplePage < Scraped::HTML
-  decorators [{ decorator: CustomHeader, greeting: 'Hello, world' }]
+  decorator CustomHeader, greeting: 'Hello, world'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ page = MyPersonPage.new(response: request.response)
 
 ### Decorated responses
 
-To manipulate the response before it is passed to the scraper create a class that subclasses `Scraped::Response::Decorator` and defines any of the following methods: `body`, `url`, `status`, `headers`.
+To manipulate the response before it is processed by the scraper create a class that subclasses `Scraped::Response::Decorator` and defines any of the following methods: `body`, `url`, `status`, `headers`.
 
 ```ruby
 class AbsoluteLinks < Scraped::Response::Decorator
@@ -135,11 +135,14 @@ end
 
 As well as the `body` method you can also supply your own `url`, `status` and `headers` methods. You can access the current request body by calling `super` from your method. You can also call `url`, `headers` or `status` to access those properties of the current response.
 
-To use a response decorator you need to supply it to the `Request#response` method:
+To use a response decorator you need to use the `decorators` class method in a `Scraped::HTML` subclass:
 
 ```ruby
-request = Scraped::Request.new(url: 'http://example.com')
-response = request.response(decorators: [AbsoluteLinks])
+class PageWithRelativeLinks < Scraped::HTML
+  decorators [AbsoluteLinks]
+
+  # Other fields...
+end
 ```
 
 ### Configuring requests and responses
@@ -153,9 +156,9 @@ class CustomHeader < Scraped::Response::Decorator
   end
 end
 
-response = Scraped::Request.new(url: url).response(decorators: [
-  { decorator: CustomHeader, greeting: 'Hello, world' }
-])
+class ExamplePage < Scraped::HTML
+  decorators [{ decorator: CustomHeader, greeting: 'Hello, world' }]
+end
 ```
 
 With the above code a custom header would be added to the response: `X-Greeting: Hello, world`.

--- a/lib/scraped.rb
+++ b/lib/scraped.rb
@@ -18,6 +18,7 @@ class Scraped
 
   def self.inherited(klass)
     klass.decorators.concat(decorators)
+    super
   end
 
   def initialize(response:)

--- a/lib/scraped.rb
+++ b/lib/scraped.rb
@@ -8,12 +8,16 @@ require_rel 'scraped'
 class Scraped
   include FieldSerializer
 
-  def self.decorators(decorators = nil)
-    @decorators ||= decorators
+  def self.decorator(klass, config = {})
+    decorators << config.merge(decorator: klass)
+  end
+
+  def self.decorators
+    @decorators ||= []
   end
 
   def self.inherited(klass)
-    klass.decorators(decorators)
+    klass.decorators.concat(decorators)
   end
 
   def initialize(response:)

--- a/lib/scraped.rb
+++ b/lib/scraped.rb
@@ -8,13 +8,28 @@ require_rel 'scraped'
 class Scraped
   include FieldSerializer
 
+  def self.decorators(decorators = nil)
+    @decorators ||= decorators
+  end
+
+  def self.inherited(klass)
+    klass.decorators(decorators)
+  end
+
   def initialize(response:)
-    @response = response
+    @original_response = response
   end
 
   private
 
-  attr_reader :response
+  attr_reader :original_response
+
+  def response
+    @response ||= ResponseDecorator.new(
+      response:   original_response,
+      decorators: self.class.decorators
+    ).response
+  end
 
   def url
     response.url

--- a/lib/scraped/request.rb
+++ b/lib/scraped/request.rb
@@ -11,14 +11,7 @@ class Scraped
     def response(decorators: [])
       abort "Failed to fetch #{url}" if first_successful_response.nil?
       response = Response.new(first_successful_response.merge(url: url))
-      decorators.reduce(response) do |r, decorator_config|
-        unless decorator_config.respond_to?(:delete)
-          decorator_config = { decorator: decorator_config }
-        end
-        decorator_class = decorator_config.delete(:decorator)
-        decorator_class.new(response: r, config: decorator_config)
-                       .decorated_response
-      end
+      ResponseDecorator.new(response: response, decorators: decorators).response
     end
 
     private

--- a/lib/scraped/response_decorator.rb
+++ b/lib/scraped/response_decorator.rb
@@ -1,0 +1,23 @@
+class Scraped
+  class ResponseDecorator
+    def initialize(response:, decorators:)
+      @original_response = response
+      @decorators = decorators.to_a
+    end
+
+    def response
+      decorators.reduce(original_response) do |r, decorator_config|
+        unless decorator_config.respond_to?(:delete)
+          decorator_config = { decorator: decorator_config }
+        end
+        decorator_class = decorator_config.delete(:decorator)
+        decorator_class.new(response: r, config: decorator_config)
+                       .decorated_response
+      end
+    end
+
+    private
+
+    attr_reader :original_response, :decorators
+  end
+end

--- a/lib/scraped/response_decorator.rb
+++ b/lib/scraped/response_decorator.rb
@@ -7,10 +7,10 @@ class Scraped
 
     def response
       decorators.reduce(original_response) do |r, decorator_config|
-        unless decorator_config.respond_to?(:delete)
+        unless decorator_config.respond_to?(:[])
           decorator_config = { decorator: decorator_config }
         end
-        decorator_class = decorator_config.delete(:decorator)
+        decorator_class = decorator_config[:decorator]
         decorator_class.new(response: r, config: decorator_config)
                        .decorated_response
       end

--- a/test/scraped_test.rb
+++ b/test/scraped_test.rb
@@ -4,4 +4,34 @@ describe Scraped do
   it 'has a version number' do
     ::Scraped::VERSION.wont_be_nil
   end
+
+  describe 'decorators' do
+    let(:response) do
+      Scraped::Response.new(body: 'Hello', url: 'http://example.com')
+    end
+
+    class UpcaseDecorator < Scraped::Response::Decorator
+      def body
+        super.upcase
+      end
+    end
+
+    class PageNoDecorators < Scraped
+      field :body do
+        response.body.to_s
+      end
+    end
+
+    class PageWithDecorators < PageNoDecorators
+      decorators [UpcaseDecorator]
+    end
+
+    it 'does not change the response with no decorators' do
+      PageNoDecorators.new(response: response).body.must_equal 'Hello'
+    end
+
+    it 'changes the body with decorator' do
+      PageWithDecorators.new(response: response).body.must_equal 'HELLO'
+    end
+  end
 end

--- a/test/scraped_test.rb
+++ b/test/scraped_test.rb
@@ -16,6 +16,12 @@ describe Scraped do
       end
     end
 
+    class FindReplaceDecorator < Scraped::Response::Decorator
+      def body
+        super.gsub(config[:find], config[:replace])
+      end
+    end
+
     class PageNoDecorators < Scraped
       field :body do
         response.body.to_s
@@ -23,7 +29,11 @@ describe Scraped do
     end
 
     class PageWithDecorators < PageNoDecorators
-      decorators [UpcaseDecorator]
+      decorator UpcaseDecorator
+    end
+
+    class PageWithConfigurableDecorators < PageNoDecorators
+      decorator FindReplaceDecorator, find: 'Hello', replace: 'Hi!'
     end
 
     it 'does not change the response with no decorators' do
@@ -32,6 +42,12 @@ describe Scraped do
 
     it 'changes the body with decorator' do
       PageWithDecorators.new(response: response).body.must_equal 'HELLO'
+    end
+
+    it 'allows configuring decorators' do
+      PageWithConfigurableDecorators.new(
+        response: response
+      ).body.must_equal 'Hi!'
     end
   end
 end

--- a/test/scraped_test.rb
+++ b/test/scraped_test.rb
@@ -36,6 +36,11 @@ describe Scraped do
       decorator FindReplaceDecorator, find: 'Hello', replace: 'Hi!'
     end
 
+    class PageWithMultipleDecorators < PageNoDecorators
+      decorator FindReplaceDecorator, find: 'Hello', replace: 'Hi!'
+      decorator UpcaseDecorator
+    end
+
     it 'does not change the response with no decorators' do
       PageNoDecorators.new(response: response).body.must_equal 'Hello'
     end
@@ -48,6 +53,12 @@ describe Scraped do
       PageWithConfigurableDecorators.new(
         response: response
       ).body.must_equal 'Hi!'
+    end
+
+    it 'works with multiple decorators' do
+      PageWithMultipleDecorators.new(
+        response: response
+      ).body.must_equal 'HI!'
     end
   end
 end

--- a/test/scraped_test.rb
+++ b/test/scraped_test.rb
@@ -41,6 +41,9 @@ describe Scraped do
       decorator UpcaseDecorator
     end
 
+    class PageInheritingDecorators < PageWithDecorators
+    end
+
     it 'does not change the response with no decorators' do
       PageNoDecorators.new(response: response).body.must_equal 'Hello'
     end
@@ -59,6 +62,12 @@ describe Scraped do
       PageWithMultipleDecorators.new(
         response: response
       ).body.must_equal 'HI!'
+    end
+
+    it 'works with inheritance' do
+      PageInheritingDecorators.new(
+        response: response
+      ).body.must_equal 'HELLO'
     end
   end
 end


### PR DESCRIPTION
We have been finding that more often than not it's better to specify decorators at the class level. If you don't specify them at the class level then there's no guarantee that the correct/expected decorators will have been run on the response before its passed to the constructor of a `Scraped` subclass.

So now creating and using a decorator looks like this:

```ruby
class CustomHeader < Scraped::Response::Decorator
  def headers
    response.headers.merge('X-Greeting' => config[:greeting])
  end
end

class ExamplePage < Scraped::HTML
  decorator CustomHeader, greeting: 'Hello, world'
end
```

Part of https://github.com/everypolitician/scraped/issues/28