### PR TITLE
Specify minimum acceptable version of field_serializer

### DIFF
--- a/scraped.gemspec
+++ b/scraped.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'nokogiri'
-  spec.add_runtime_dependency 'field_serializer'
+  spec.add_runtime_dependency 'field_serializer', '>= 0.3.0'
   spec.add_runtime_dependency 'require_all'
 
   spec.add_development_dependency 'bundler', '~> 1.13'


### PR DESCRIPTION
`field_serializer` before v0.3.0 had a bug with inheritance. This meant subclasses didn't inherit their parent classes fields. Since this can lead to some _very_ confusing bugs I think it's best to only support versions that don't have the fix for that bug.

Fixes https://github.com/everypolitician/scraped/issues/33