### PR TITLE
Update docs for creating request strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class FileOnDiskRequest < Scraped::Request::Strategy
 end
 ```
 
-The `response` method should return a `Hash` which has at least a `body` key. You can also include `status` and `headers` parameters in the hash to fill out those fields in the response. If not given status will default to `200` and headers will default to `{}`.
+The `response` method should return a `Hash` which has at least a `body` key. You can also include `status` and `headers` parameters in the hash to fill out those fields in the response. If not given, status will default to `200` and headers will default to `{}`.
 
 To use a custom request strategy pass it to `Scraped::Request`:
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class FileOnDiskRequest < Scraped::Request::Strategy
 end
 ```
 
-The `response` method should return a `Hash` which has at least a `body` key. You can also include `status` and `headers` parameters in the hash to fill out those fields in the response. If not given, status will default to `200` and headers will default to `{}`.
+The `response` method should return a `Hash` which has at least a `body` key. You can also include `status` and `headers` parameters in the hash to fill out those fields in the response. If not given, status will default to `200` (OK) and headers will default to `{}`.
 
 To use a custom request strategy pass it to `Scraped::Request`:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To make a custom request you'll need to create a class that subclasses `Scraped:
 ```ruby
 class FileOnDiskRequest < Scraped::Request::Strategy
   def response
-    Response.new(url: url, body: open(filename).read)
+    { body: open(filename).read }
   end
 
   private
@@ -108,7 +108,7 @@ class FileOnDiskRequest < Scraped::Request::Strategy
 end
 ```
 
-The `response` method should return a `Response` instance. You need to pass at least `url` and `body` parameters to the `Response` constructor. You can also pass `status` and `headers` parameters.
+The `response` method should return a `Hash` which has at least a `body` key. You can also include `status` and `headers` parameters in the hash to fill out those fields in the response. If not given status will default to `200` and headers will default to `{}`.
 
 To use a custom request strategy pass it to `Scraped::Request`:
 


### PR DESCRIPTION
These were still using the old method of passing a `Scraped::Response`
instance around. Instead we now just pass a hash around to reduce the
strategies dependency on internal classes.

Fixes https://github.com/everypolitician/scraped/issues/36