### PR TITLE
Add decorator to make links and images absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ end
 
 ## Extending
 
-There are two main ways to extend `scraped` with your own custom logic - custom requests and decorated responses. Custom requests allow you to change where the scraper is getting its responses from, e.g. you might want to make requests to archive.org if the site you're scraping has disappeared. Decorated responses allow you to manipulate the response before it's passed to the scraper. For example you might want to make all the links on the page absolute rather than relative.
+There are two main ways to extend `scraped` with your own custom logic - custom requests and decorated responses. Custom requests allow you to change where the scraper is getting its responses from, e.g. you might want to make requests to archive.org if the site you're scraping has disappeared. Decorated responses allow you to manipulate the response before it's passed to the scraper. Scraped comes with some [built in decorators](#built-in-decorators) for common tasks such as making all the link urls on the page absolute rather than relative.
 
 ### Custom request strategies
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ class AllMembersPage < Scraped::HTML
 end
 ```
 
+### Absolute link and image urls
+
+Very frequently you will find that you need to make links and images on the page
+you are scraping absolute rather than relative. Scraped comes with support for
+this out of the box via the `Scraped::Response::Decorator::AbsoluteUrls`
+decorator.
+
+```ruby
+require 'scraped'
+
+class MemberPage < Scraped::HTML
+  decorator Scraped::Response::Decorator::AbsoluteUrls
+
+  field :image do
+    # Image url will be absolute thanks to the decorator.
+    noko.at_css('.profile-picture/@src').text
+  end
+end
+```
+
 ## Extending
 
 There are two main ways to extend `scraped` with your own custom logic - custom requests and decorated responses. Custom requests allow you to change where the scraper is getting its responses from, e.g. you might want to make requests to archive.org if the site you're scraping has disappeared. Decorated responses allow you to manipulate the response before it's passed to the scraper. For example you might want to make all the links on the page absolute rather than relative.

--- a/README.md
+++ b/README.md
@@ -86,26 +86,6 @@ class AllMembersPage < Scraped::HTML
 end
 ```
 
-### Absolute link and image urls
-
-Very frequently you will find that you need to make links and images on the page
-you are scraping absolute rather than relative. Scraped comes with support for
-this out of the box via the `Scraped::Response::Decorator::AbsoluteUrls`
-decorator.
-
-```ruby
-require 'scraped'
-
-class MemberPage < Scraped::HTML
-  decorator Scraped::Response::Decorator::AbsoluteUrls
-
-  field :image do
-    # Image url will be absolute thanks to the decorator.
-    noko.at_css('.profile-picture/@src').text
-  end
-end
-```
-
 ## Extending
 
 There are two main ways to extend `scraped` with your own custom logic - custom requests and decorated responses. Custom requests allow you to change where the scraper is getting its responses from, e.g. you might want to make requests to archive.org if the site you're scraping has disappeared. Decorated responses allow you to manipulate the response before it's passed to the scraper. For example you might want to make all the links on the page absolute rather than relative.
@@ -186,6 +166,28 @@ With the above code a custom header would be added to the response: `X-Greeting:
 #### Inheritance with decorators
 
 When you inherit from a class that already has decorators the child class will also inherit the parent's decorators. There's currently no way to re-order or remove decorators in child classes, though that _may_ be added in the future.
+
+### Built in decorators
+
+#### Absolute link and image urls
+
+Very frequently you will find that you need to make links and images on the page
+you are scraping absolute rather than relative. Scraped comes with support for
+this out of the box via the `Scraped::Response::Decorator::AbsoluteUrls`
+decorator.
+
+```ruby
+require 'scraped'
+
+class MemberPage < Scraped::HTML
+  decorator Scraped::Response::Decorator::AbsoluteUrls
+
+  field :image do
+    # Image url will be absolute thanks to the decorator.
+    noko.at_css('.profile-picture/@src').text
+  end
+end
+```
 
 ## Development
 

--- a/lib/scraped/response/decorator/absolute_urls.rb
+++ b/lib/scraped/response/decorator/absolute_urls.rb
@@ -7,9 +7,15 @@ class Scraped
       class AbsoluteUrls < Decorator
         def body
           Nokogiri::HTML(super).tap do |doc|
-            doc.css('img').each { |img| img[:src] = URI.join(url, img[:src]) }
-            doc.css('a').each { |a| a[:href] = URI.join(url, a[:href]) }
+            doc.css('img').each { |img| img[:src] = absolute_url(img[:src]) }
+            doc.css('a').each { |a| a[:href] = absolute_url(a[:href]) }
           end.to_s
+        end
+
+        private
+
+        def absolute_url(relative_url)
+          URI.join(url, relative_url) unless relative_url.to_s.empty?
         end
       end
     end

--- a/lib/scraped/response/decorator/absolute_urls.rb
+++ b/lib/scraped/response/decorator/absolute_urls.rb
@@ -1,0 +1,17 @@
+require 'nokogiri'
+require 'uri'
+
+class Scraped
+  class Response
+    class Decorator
+      class AbsoluteUrls < Decorator
+        def body
+          Nokogiri::HTML(super).tap do |doc|
+            doc.css('img').each { |img| img[:src] = URI.join(url, img[:src]) }
+            doc.css('a').each { |a| a[:href] = URI.join(url, a[:href]) }
+          end.to_s
+        end
+      end
+    end
+  end
+end

--- a/test/scraped/response/decorator/absolute_urls_test.rb
+++ b/test/scraped/response/decorator/absolute_urls_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+describe Scraped::Response::Decorator::AbsoluteUrls do
+  let(:body) do
+    <<-BODY
+    <img class="relative-image" src="/person-123.jpg">
+    <img class="absolute-image" src="http://example.com/person-123-square.jpg">
+    <img class="external-image" src="http://example.org/person-123-alternative.jpg">
+
+    <a class="relative-link" href="/person-123">Person 123</a>
+    <a class="absolute-link" href="http://example.com/person-123-contact">Person 123</a>
+    <a class="external-link" href="http://example.org/person-123-other-page">Person 123</a>
+    BODY
+  end
+
+  let(:response) do
+    Scraped::Response.new(url: 'http://example.com', body: body)
+  end
+
+  let(:page) { PageWithAbsoluteUrlsDecorator.new(response: response) }
+
+  class PageWithAbsoluteUrlsDecorator < Scraped::HTML
+    decorator Scraped::Response::Decorator::AbsoluteUrls
+
+    field :relative_image do
+      img('.relative-image')
+    end
+
+    field :absolute_image do
+      img('.absolute-image')
+    end
+
+    field :external_image do
+      img('.external-image')
+    end
+
+    field :relative_link do
+      link('.relative-link')
+    end
+
+    field :absolute_link do
+      link('.absolute-link')
+    end
+
+    field :external_link do
+      link('.external-link')
+    end
+
+    private
+
+    def img(selector)
+      noko.at_css("#{selector}/@src").text
+    end
+
+    def link(selector)
+      noko.at_css("#{selector}/@href").text
+    end
+  end
+
+  it 'makes relative images absolute' do
+    page.relative_image.must_equal 'http://example.com/person-123.jpg'
+  end
+
+  it 'leaves absolute images alone' do
+    page.absolute_image.must_equal 'http://example.com/person-123-square.jpg'
+  end
+
+  it 'leaves external images alone' do
+    page.external_image.must_equal 'http://example.org/person-123-alternative.jpg'
+  end
+
+  it 'makes relative links absolute' do
+    page.relative_link.must_equal 'http://example.com/person-123'
+  end
+
+  it 'leaves absolute links alone' do
+    page.absolute_link.must_equal 'http://example.com/person-123-contact'
+  end
+
+  it 'leaves external links alone' do
+    page.external_link.must_equal 'http://example.org/person-123-other-page'
+  end
+end

--- a/test/scraped/response/decorator/absolute_urls_test.rb
+++ b/test/scraped/response/decorator/absolute_urls_test.rb
@@ -6,10 +6,12 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
     <img class="relative-image" src="/person-123.jpg">
     <img class="absolute-image" src="http://example.com/person-123-square.jpg">
     <img class="external-image" src="http://example.org/person-123-alternative.jpg">
+    <img class="empty-image" src="">
 
     <a class="relative-link" href="/person-123">Person 123</a>
     <a class="absolute-link" href="http://example.com/person-123-contact">Person 123</a>
     <a class="external-link" href="http://example.org/person-123-other-page">Person 123</a>
+    <a class="empty-link" href="">Person 123</a>
     BODY
   end
 
@@ -34,6 +36,10 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
       img('.external-image')
     end
 
+    field :empty_image do
+      img('.empty-image')
+    end
+
     field :relative_link do
       link('.relative-link')
     end
@@ -44,6 +50,10 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
 
     field :external_link do
       link('.external-link')
+    end
+
+    field :empty_link do
+      link('.empty-link')
     end
 
     private
@@ -69,6 +79,10 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
     page.external_image.must_equal 'http://example.org/person-123-alternative.jpg'
   end
 
+  it 'leaves empty image src attributes alone' do
+    page.empty_image.must_equal ''
+  end
+
   it 'makes relative links absolute' do
     page.relative_link.must_equal 'http://example.com/person-123'
   end
@@ -79,5 +93,9 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
 
   it 'leaves external links alone' do
     page.external_link.must_equal 'http://example.org/person-123-other-page'
+  end
+
+  it 'leaves empty link href attributes alone' do
+    page.empty_link.must_equal ''
   end
 end


### PR DESCRIPTION
This adds a decorator that when used will make all `<a>` and/or `<img />` elements have absolute urls in their `href` and `src` attributes respectively.

Fixes https://github.com/everypolitician/scraped/issues/38

# Notes to reviewer

I couldn't decide whether it would be better to have three separate decorators (one for images, one for links and one that is a composite of both) or just one that does both images and links. I decided to go for the simplest option and just create one decorator for now, but I'm open to changing it if there's an obvious use case for that.