### PR TITLE
AbsoluteUrls: Handle urls that can't be parsed

### DIFF
--- a/lib/scraped/response/decorator/absolute_urls.rb
+++ b/lib/scraped/response/decorator/absolute_urls.rb
@@ -16,6 +16,8 @@ class Scraped
 
         def absolute_url(relative_url)
           URI.join(url, relative_url) unless relative_url.to_s.empty?
+        rescue URI::InvalidURIError
+          relative_url
         end
       end
     end

--- a/test/scraped/response/decorator/absolute_urls_test.rb
+++ b/test/scraped/response/decorator/absolute_urls_test.rb
@@ -12,6 +12,7 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
     <a class="absolute-link" href="http://example.com/person-123-contact">Person 123</a>
     <a class="external-link" href="http://example.org/person-123-other-page">Person 123</a>
     <a class="empty-link" href="">Person 123</a>
+    <a class="javascript-link" href="javascript:chooseStyle('small',60);">Person 123</a>
     BODY
   end
 
@@ -56,6 +57,10 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
       link('.empty-link')
     end
 
+    field :javascript_link do
+      link('.javascript-link')
+    end
+
     private
 
     def img(selector)
@@ -93,6 +98,10 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
 
   it 'leaves external links alone' do
     page.external_link.must_equal 'http://example.org/person-123-other-page'
+  end
+
+  it "doesn't raise an exception for javascript links" do
+    page.javascript_link.must_equal "javascript:chooseStyle('small',60);"
   end
 
   it 'leaves empty link href attributes alone' do


### PR DESCRIPTION
This rescues any URI parsing errors and just returns the original url
rather than blowing up.

I did consider adding a warning if we're unable to parse the url, but
this made the tests very noisy and would probably be too much output on
Morph, so I've left it for now. That can be a future enhancement.

Fixes #40 