### PR TITLE
Add String#tidy method

### DIFF
--- a/lib/scraped/core_ext.rb
+++ b/lib/scraped/core_ext.rb
@@ -1,0 +1,5 @@
+class String
+  def tidy
+    gsub(/[[:space:]]+/, ' ').strip
+  end
+end

--- a/test/scraped/core_ext_test.rb
+++ b/test/scraped/core_ext_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+describe 'Core extensions' do
+  it 'adds a String#tidy method' do
+    ' test '.tidy.must_equal 'test'
+  end
+end


### PR DESCRIPTION
This method is used in lots of EveryPolitician scrapers, so having it
come out of the box with scraped will help reduce duplication.

I initially attempted to do this using refinements, but couldn't get it
working in a satisfactory way. I think it's probably going to be less
confusing and require less debugging time to just do it the "old
fashioned" way and monkey patch the class directly.

Fixes #8 