### PR TITLE
Add Scraped::Document class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.2.0 - 2017-01-04
+
+### Changed
+
+- The logic that was in the `Scraped` class is now in `Scraped::Base`.
+- `Scraped::HTML` now inherits from `Scraped::Base` rather than `Scraped`.
+- The top level `Scraped` constant is now a `module` instead of a `class`.
+
 ## 0.1.0 - 2017-01-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- The logic that was in the `Scraped` class is now in `Scraped::Base`.
-- `Scraped::HTML` now inherits from `Scraped::Base` rather than `Scraped`.
+- The logic that was in the `Scraped` class is now in `Scraped::Document`.
+- `Scraped::HTML` now inherits from `Scraped::Document` rather than `Scraped`.
 - The top level `Scraped` constant is now a `module` instead of a `class`.
 
 ## 0.1.0 - 2017-01-04

--- a/lib/scraped.rb
+++ b/lib/scraped.rb
@@ -1,42 +1,6 @@
 # frozen_string_literal: true
-require 'nokogiri'
-require 'field_serializer'
 require 'require_all'
 require_rel 'scraped'
 
-# Abstract class which scrapers can extend to implement their functionality.
 class Scraped
-  include FieldSerializer
-
-  def self.decorator(klass, config = {})
-    decorators << config.merge(decorator: klass)
-  end
-
-  def self.decorators
-    @decorators ||= []
-  end
-
-  def self.inherited(klass)
-    klass.decorators.concat(decorators)
-    super
-  end
-
-  def initialize(response:)
-    @original_response = response
-  end
-
-  private
-
-  attr_reader :original_response
-
-  def response
-    @response ||= ResponseDecorator.new(
-      response:   original_response,
-      decorators: self.class.decorators
-    ).response
-  end
-
-  def url
-    response.url
-  end
 end

--- a/lib/scraped.rb
+++ b/lib/scraped.rb
@@ -2,5 +2,5 @@
 require 'require_all'
 require_rel 'scraped'
 
-class Scraped
+module Scraped
 end

--- a/lib/scraped/base.rb
+++ b/lib/scraped/base.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'nokogiri'
+require 'field_serializer'
+
+class Scraped
+  # Abstract class which scrapers can extend to implement their functionality.
+  class Base
+    include FieldSerializer
+
+    def self.decorator(klass, config = {})
+      decorators << config.merge(decorator: klass)
+    end
+
+    def self.decorators
+      @decorators ||= []
+    end
+
+    def self.inherited(klass)
+      klass.decorators.concat(decorators)
+      super
+    end
+
+    def initialize(response:)
+      @original_response = response
+    end
+
+    private
+
+    attr_reader :original_response
+
+    def response
+      @response ||= ResponseDecorator.new(
+        response:   original_response,
+        decorators: self.class.decorators
+      ).response
+    end
+
+    def url
+      response.url
+    end
+  end
+end

--- a/lib/scraped/base.rb
+++ b/lib/scraped/base.rb
@@ -2,7 +2,7 @@
 require 'nokogiri'
 require 'field_serializer'
 
-class Scraped
+module Scraped
   # Abstract class which scrapers can extend to implement their functionality.
   class Base
     include FieldSerializer

--- a/lib/scraped/document.rb
+++ b/lib/scraped/document.rb
@@ -4,7 +4,7 @@ require 'field_serializer'
 
 module Scraped
   # Abstract class which scrapers can extend to implement their functionality.
-  class Base
+  class Document
     include FieldSerializer
 
     def self.decorator(klass, config = {})

--- a/lib/scraped/html.rb
+++ b/lib/scraped/html.rb
@@ -1,5 +1,5 @@
 class Scraped
-  class HTML < Scraped
+  class HTML < Scraped::Base
     private
 
     def initialize(noko: nil, **args)

--- a/lib/scraped/html.rb
+++ b/lib/scraped/html.rb
@@ -1,4 +1,4 @@
-class Scraped
+module Scraped
   class HTML < Scraped::Base
     private
 

--- a/lib/scraped/html.rb
+++ b/lib/scraped/html.rb
@@ -1,5 +1,5 @@
 module Scraped
-  class HTML < Scraped::Base
+  class HTML < Scraped::Document
     private
 
     def initialize(noko: nil, **args)

--- a/lib/scraped/request.rb
+++ b/lib/scraped/request.rb
@@ -1,7 +1,7 @@
 require 'scraped/request/strategy/live_request'
 require 'scraped/response'
 
-class Scraped
+module Scraped
   class Request
     def initialize(url:, strategies: [Strategy::LiveRequest])
       @url = url

--- a/lib/scraped/request/strategy.rb
+++ b/lib/scraped/request/strategy.rb
@@ -1,4 +1,4 @@
-class Scraped
+module Scraped
   class Request
     class Strategy
       class NotImplementedError < StandardError; end

--- a/lib/scraped/request/strategy/live_request.rb
+++ b/lib/scraped/request/strategy/live_request.rb
@@ -1,7 +1,7 @@
 require 'scraped/request/strategy'
 require 'open-uri'
 
-class Scraped
+module Scraped
   class Request
     class Strategy
       class LiveRequest < Strategy

--- a/lib/scraped/response.rb
+++ b/lib/scraped/response.rb
@@ -1,4 +1,4 @@
-class Scraped
+module Scraped
   class Response
     attr_reader :status, :headers, :body, :url
 

--- a/lib/scraped/response/decorator.rb
+++ b/lib/scraped/response/decorator.rb
@@ -1,4 +1,4 @@
-class Scraped
+module Scraped
   class Response
     class Decorator
       def initialize(response:, config: {})

--- a/lib/scraped/response/decorator/absolute_urls.rb
+++ b/lib/scraped/response/decorator/absolute_urls.rb
@@ -1,7 +1,7 @@
 require 'nokogiri'
 require 'uri'
 
-class Scraped
+module Scraped
   class Response
     class Decorator
       class AbsoluteUrls < Decorator

--- a/lib/scraped/response_decorator.rb
+++ b/lib/scraped/response_decorator.rb
@@ -1,4 +1,4 @@
-class Scraped
+module Scraped
   class ResponseDecorator
     def initialize(response:, decorators:)
       @original_response = response

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
-class Scraped
+module Scraped
   VERSION = '0.1.0'.freeze
 end

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
 module Scraped
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/test/scraped_test.rb
+++ b/test/scraped_test.rb
@@ -22,7 +22,7 @@ describe Scraped do
       end
     end
 
-    class PageNoDecorators < Scraped
+    class PageNoDecorators < Scraped::Base
       field :body do
         response.body.to_s
       end

--- a/test/scraped_test.rb
+++ b/test/scraped_test.rb
@@ -22,7 +22,7 @@ describe Scraped do
       end
     end
 
-    class PageNoDecorators < Scraped::Base
+    class PageNoDecorators < Scraped::Document
       field :body do
         response.body.to_s
       end


### PR DESCRIPTION
We have run into a couple of problems with the top level `Scraped` constant being a `class` and not a `module`. The problem with it being a class is that it makes it tricky to add helper methods because any dependencies added to `Scraped` are inherited by subclasses such as `Scraped::HTML`. By adding a `Scraped::Document` class we can free up the top level to be a simple namespace module, which we can then add helper methods to in the future.

Calling this new class `Scraped::Document` also makes inheriting from it a bit nicer, e.g. when we add a `Scraped::XML` class it will inherit from `Scraped::Document`, which is a bit more OO.