### PR TITLE
Absolute urls decorator: encode urls correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.3.0 - 2017-01-10
+
+### Changed
+
+- The AbsoluteUrls decorator now ensures the URL is correctly encoded
+  (e.g. by transforming spaces into %20)
+
 ## 0.2.0 - 2017-01-04
 
 ### Changed

--- a/lib/scraped/response/decorator/absolute_urls.rb
+++ b/lib/scraped/response/decorator/absolute_urls.rb
@@ -15,7 +15,12 @@ module Scraped
         private
 
         def absolute_url(relative_url)
-          URI.join(url, relative_url) unless relative_url.to_s.empty?
+          unless relative_url.to_s.empty?
+            URI.join(url, URI.encode(
+              # To prevent encoded URLs from being encoded twice
+              URI.decode(relative_url)
+            ).gsub('[', '%5B').gsub(']', '%5D')).to_s
+          end
         rescue URI::InvalidURIError
           relative_url
         end

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
 module Scraped
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/test/scraped/response/decorator/absolute_urls_test.rb
+++ b/test/scraped/response/decorator/absolute_urls_test.rb
@@ -13,6 +13,9 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
     <a class="external-link" href="http://example.org/person-123-other-page">Person 123</a>
     <a class="empty-link" href="">Person 123</a>
     <a class="javascript-link" href="javascript:chooseStyle('small',60);">Person 123</a>
+    <a class="bracketed-link" href="/person[123]">Person 123</a>
+    <a class="relative-link-with-unencoded-space" href="/person 123">Person 123</a>
+    <a class="encoded-url" href="/person%20123">Person 123</a>
     BODY
   end
 
@@ -61,6 +64,18 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
       link('.javascript-link')
     end
 
+    field :bracketed_link do
+      link('.bracketed-link')
+    end
+
+    field :relative_link_with_unencoded_space do
+      link('.relative-link-with-unencoded-space')
+    end
+
+    field :encoded_url do
+      link('.encoded-url')
+    end
+
     private
 
     def img(selector)
@@ -106,5 +121,17 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
 
   it 'leaves empty link href attributes alone' do
     page.empty_link.must_equal ''
+  end
+
+  it 'handles square brackets' do
+    page.bracketed_link.must_equal 'http://example.com/person%5B123%5D'
+  end
+
+  it 'encodes space characters' do
+    page.relative_link_with_unencoded_space.must_equal 'http://example.com/person%20123'
+  end
+
+  it 'should not encode already encoded URLs' do
+    page.encoded_url.must_equal 'http://example.com/person%20123'
   end
 end


### PR DESCRIPTION
Addresses https://github.com/everypolitician/scraped/issues/52

Changes Absolute URL decorator so that it can handle URLs containing spaces.