### PR TITLE
Absolute urls decorator: Use base URL if provided by document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.4.0 - 2017-01-27
+
+### Changed
+
+- The AbsoluteUrls decorator uses the base URL provided by the document. If one is not provided, it uses the document URL.
+
 ## 0.3.0 - 2017-01-10
 
 ### Changed

--- a/lib/scraped/response/decorator/absolute_urls.rb
+++ b/lib/scraped/response/decorator/absolute_urls.rb
@@ -7,6 +7,7 @@ module Scraped
       class AbsoluteUrls < Decorator
         def body
           Nokogiri::HTML(super).tap do |doc|
+            @doc = doc
             doc.css('img').each { |img| img[:src] = absolute_url(img[:src]) }
             doc.css('a').each { |a| a[:href] = absolute_url(a[:href]) }
           end.to_s
@@ -14,15 +15,22 @@ module Scraped
 
         private
 
+        attr_reader :doc
+
         def absolute_url(relative_url)
           unless relative_url.to_s.empty?
-            URI.join(url, URI.encode(
+            URI.join(base_url, URI.encode(
               # To prevent encoded URLs from being encoded twice
               URI.decode(relative_url)
             ).gsub('[', '%5B').gsub(']', '%5D')).to_s
           end
         rescue URI::InvalidURIError
           relative_url
+        end
+
+        def base_url
+          return url if (base = doc.css('base @href').text).empty?
+          base
         end
       end
     end

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
 module Scraped
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/test/scraped/response/decorator/absolute_urls_test.rb
+++ b/test/scraped/response/decorator/absolute_urls_test.rb
@@ -19,7 +19,7 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
     BODY
   end
 
-  let (:body_with_base) do
+  let :body_with_base do
     <<-BODY
     <base href="http://www.example.com/" />
     <a class="relative-link" href="/person-123">Person 123</a>
@@ -30,12 +30,14 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
     Scraped::Response.new(url: 'http://example.com', body: body)
   end
 
-  let(:body_with_base_response) do
-    Scraped::Response.new(url: 'http://example.com', body: body)
+  let :body_with_base_response do
+    Scraped::Response.new(url: 'http://example.com', body: body_with_base)
   end
 
   let(:page) { PageWithAbsoluteUrlsDecorator.new(response: response) }
-  let(:page_with_base) { PageWithAbsoluteUrlsDecorator.new(response: response) }
+  let :page_with_base do
+    PageWithAbsoluteUrlsDecorator.new(response: body_with_base_response)
+  end
 
   class PageWithAbsoluteUrlsDecorator < Scraped::HTML
     decorator Scraped::Response::Decorator::AbsoluteUrls

--- a/test/scraped/response/decorator/absolute_urls_test.rb
+++ b/test/scraped/response/decorator/absolute_urls_test.rb
@@ -19,11 +19,23 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
     BODY
   end
 
+  let (:body_with_base) do
+    <<-BODY
+    <base href="http://www.example.com/" />
+    <a class="relative-link" href="/person-123">Person 123</a>
+    BODY
+  end
+
   let(:response) do
     Scraped::Response.new(url: 'http://example.com', body: body)
   end
 
+  let(:body_with_base_response) do
+    Scraped::Response.new(url: 'http://example.com', body: body)
+  end
+
   let(:page) { PageWithAbsoluteUrlsDecorator.new(response: response) }
+  let(:page_with_base) { PageWithAbsoluteUrlsDecorator.new(response: response) }
 
   class PageWithAbsoluteUrlsDecorator < Scraped::HTML
     decorator Scraped::Response::Decorator::AbsoluteUrls
@@ -133,5 +145,9 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
 
   it 'should not encode already encoded URLs' do
     page.encoded_url.must_equal 'http://example.com/person%20123'
+  end
+
+  it 'should use a base url provided by the document' do
+    page_with_base.relative_link.must_equal 'http://www.example.com/person-123'
   end
 end


### PR DESCRIPTION
Fixes https://github.com/everypolitician/scraped/issues/58

When a document provides a base URL within a `<base>` tag, we want to use that as the base, instead of the page URL.