### PR TITLE
Instruct rubocop to ignore gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,10 @@ inherit_from:
 
 Style/SingleLineBlockParams:
   Enabled: false
+
+# Minitest::Spec uses long blocks to contains the specs, so disable this check
+# for the tests.
+Metrics/BlockLength:
+  Max: 10
+  Exclude:
+    - './scraped.gemspec'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,4 @@ Metrics/BlockLength:
   Max: 10
   Exclude:
     - './scraped.gemspec'
+    - 'test/**/*'


### PR DESCRIPTION
The `scraped.gemspec` is no longer passing rubocop despite being unchanged. This PR instructs rubicon to ignore the file.