### PR TITLE
Handle all URI::Error exceptions in AbsoluteUrls decorator

### DIFF
--- a/lib/scraped/response/decorator/absolute_urls.rb
+++ b/lib/scraped/response/decorator/absolute_urls.rb
@@ -18,7 +18,7 @@ module Scraped
                 URI.decode(relative_url)
               ).gsub('[', '%5B').gsub(']', '%5D')).to_s
             end
-          rescue URI::InvalidURIError
+          rescue URI::Error
             relative_url
           end
 

--- a/test/scraped/response/decorator/absolute_urls_test.rb
+++ b/test/scraped/response/decorator/absolute_urls_test.rb
@@ -16,6 +16,7 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
     <a class="bracketed-link" href="/person[123]">Person 123</a>
     <a class="relative-link-with-unencoded-space" href="/person 123">Person 123</a>
     <a class="encoded-url" href="/person%20123">Person 123</a>
+    <a class="broken-mailto-link" href="mailto:notanemail">Person 123</a>
     BODY
   end
 
@@ -76,6 +77,10 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
       link('.encoded-url')
     end
 
+    field :broken_mailto_link do
+      link('.broken-mailto-link')
+    end
+
     private
 
     def img(selector)
@@ -133,5 +138,9 @@ describe Scraped::Response::Decorator::AbsoluteUrls do
 
   it 'should not encode already encoded URLs' do
     page.encoded_url.must_equal 'http://example.com/person%20123'
+  end
+
+  it 'ignores invalid mailto links' do
+    page.broken_mailto_link.must_equal 'mailto:notanemail'
   end
 end


### PR DESCRIPTION
We were previously rescuing from `URI::InvalidURIError`, but not from `URI::InvalidComponentError`, which is the problem reported in #65, or from `URI::BadURIError`.

To ensure we handle any kind of error when parsing a URI I’ve changed the rescue to handle any `URI::Error` subclass.

Fixes #65 