### PR TITLE
Ensure pull request tests fail on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rvm:
   - 2.2
   - 2.3.1
 before_install: gem install bundler -v 1.13.5
+script:
+  - bin/check-fail.sh
+  - bundle exec rake

--- a/bin/check-fail.sh
+++ b/bin/check-fail.sh
@@ -31,6 +31,7 @@ done
 if bundle exec rake test
 then
     echo "Your newly introduced tests should have failed on $TARGET_BRANCH"
+    echo "If you expected them to pass then include 'refactor' in the branch name"
     exit 1
 else
     echo "Your new tests failed on $TARGET_BRANCH, which is a good thing!"

--- a/bin/check-fail.sh
+++ b/bin/check-fail.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+if [ "$TRAVIS_PULL_REQUEST" = false ]
+then
+  echo "Skipping $0 for non-PR build"
+  exit 0
+fi
+
+TARGET_BRANCH="$TRAVIS_BRANCH"
+if echo "$TRAVIS_PULL_REQUEST_BRANCH" | grep -qi refactor
+then
+    echo "The title of the PR indicates this is a refactoring; skipping this check"
+    exit 0
+fi
+
+if [ x"$TARGET_BRANCH" = x ]
+then
+    echo "No target branch found"
+    exit 1
+fi
+
+git checkout "$TARGET_BRANCH"
+
+for d in t tests test spec
+do
+    git checkout HEAD@{1} -- $d 2> /dev/null || true
+done
+
+if bundle exec rake test
+then
+    echo "Your newly introduced tests should have failed on $TARGET_BRANCH"
+    exit 1
+else
+    echo "Your new tests failed on $TARGET_BRANCH, which is a good thing!"
+fi


### PR DESCRIPTION
This script checks that the tests fail on master and pass for the pull request, allowing us to require regression tests for pull requests.

This uses the code originally developed in https://github.com/everypolitician/everypolitician-popolo/pull/122.

Part of https://github.com/everypolitician/everypolitician/issues/573

# Notes to reviewer

I've included a `refactor/` prefix in the branch name. The script checks for this and if found it won't run the tests on `master`. This makes sense for this pull request as this change _doesn't_ need to fail on `master`.
