### PR TITLE
[refactor] Add AbsoluteUrl class

### DIFF
--- a/lib/scraped/response/decorator/absolute_urls.rb
+++ b/lib/scraped/response/decorator/absolute_urls.rb
@@ -5,6 +5,28 @@ module Scraped
   class Response
     class Decorator
       class AbsoluteUrls < Decorator
+        class AbsoluteUrl
+          def initialize(base_url:, relative_url:)
+            @base_url = base_url
+            @relative_url = relative_url
+          end
+
+          def to_s
+            unless relative_url.to_s.empty?
+              URI.join(base_url, URI.encode(
+                # To prevent encoded URLs from being encoded twice
+                URI.decode(relative_url)
+              ).gsub('[', '%5B').gsub(']', '%5D')).to_s
+            end
+          rescue URI::InvalidURIError
+            relative_url
+          end
+
+          private
+
+          attr_reader :base_url, :relative_url
+        end
+
         def body
           Nokogiri::HTML(super).tap do |doc|
             doc.css('img').each { |img| img[:src] = absolute_url(img[:src]) }
@@ -15,14 +37,7 @@ module Scraped
         private
 
         def absolute_url(relative_url)
-          unless relative_url.to_s.empty?
-            URI.join(url, URI.encode(
-              # To prevent encoded URLs from being encoded twice
-              URI.decode(relative_url)
-            ).gsub('[', '%5B').gsub(']', '%5D')).to_s
-          end
-        rescue URI::InvalidURIError
-          relative_url
+          AbsoluteUrl.new(base_url: url, relative_url: relative_url).to_s
         end
       end
     end


### PR DESCRIPTION
This refactoring introduces a new `AbsoluteUrl` class. This encapsulates the steps for joining a base url and a relative url.

This should make it easier to extract method for checking that the relative url is a valid url according to `URI.parse`, which is useful for fixing https://github.com/everypolitician/scraped/issues/65. It also helps control the complexity of the `AbsoluteUrls#absolute_url` method.

Part of #65 