### PR TITLE
Handle all URI::Error exceptions in AbsoluteUrls decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.5.1 - 2017-03-28
+
+### Fixed
+
+- `Scraped::Response::Decorator::AbsoluteUrls` now handles all `URI::Error` exceptions. [#65](https://github.com/everypolitician/scraped/issues/65).
+
 ## 0.5.0 - 2017-03-17
 
 ### Added

--- a/lib/scraped/response/decorator/clean_urls.rb
+++ b/lib/scraped/response/decorator/clean_urls.rb
@@ -18,7 +18,7 @@ module Scraped
                 URI.decode(relative_url)
               ).gsub('[', '%5B').gsub(']', '%5D')).to_s
             end
-          rescue URI::InvalidURIError
+          rescue URI::Error
             relative_url
           end
 

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
 module Scraped
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.5.1'.freeze
 end

--- a/test/scraped/response/decorator/clean_urls_test.rb
+++ b/test/scraped/response/decorator/clean_urls_test.rb
@@ -16,6 +16,7 @@ describe Scraped::Response::Decorator::CleanUrls do
     <a class="bracketed-link" href="/person[123]">Person 123</a>
     <a class="relative-link-with-unencoded-space" href="/person 123">Person 123</a>
     <a class="encoded-url" href="/person%20123">Person 123</a>
+    <a class="broken-mailto-link" href="mailto:notanemail">Person 123</a>
     BODY
   end
 
@@ -76,6 +77,10 @@ describe Scraped::Response::Decorator::CleanUrls do
       link('.encoded-url')
     end
 
+    field :broken_mailto_link do
+      link('.broken-mailto-link')
+    end
+
     private
 
     def img(selector)
@@ -133,5 +138,9 @@ describe Scraped::Response::Decorator::CleanUrls do
 
   it 'should not encode already encoded URLs' do
     page.encoded_url.must_equal 'http://example.com/person%20123'
+  end
+
+  it 'ignores invalid mailto links' do
+    page.broken_mailto_link.must_equal 'mailto:notanemail'
   end
 end


### PR DESCRIPTION
Previously we were only handling `URI::InvalidURIError` exceptions in the AbsoluteUrls decorator, but there's also `URI::BadURIError` and `URI::InvalidComponentError`.

We have encountered quite a few `URI::InvalidComponentError` exceptions in scrapers on pages which have invalid `mailto:` links, and these weren't being handled by the decorator correctly.

This change alters the `rescue` clause to use `URI::Error` so that we can rescue from all of these types of error and return the original relative url untouched, rather than blowing up.

Fixes #65 

# Notes to reviewer

This change was originally done in https://github.com/everypolitician/scraped/pull/66 but the `check-fail.sh` script was failing, see https://github.com/everypolitician/scraped/pull/66#issuecomment-281114063 for more details.