### PR TITLE
Add request headers option to strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.5.0 - 2017-03-17
+
+### Added
+
+- Add `headers:` parameter to `Scraped::Request.new` for passing request
+  headers to the underlying strategy.
+
 ## 0.4.0 - 2017-03-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ class AllMembersPage < Scraped::HTML
 end
 ```
 
+### Passing request headers
+
+To set request headers you can pass a `headers:` argument to `Scraped::Request.new`:
+
+```ruby
+response = Scraped::Request.new(url: 'http://example.com', headers: { 'Cookie' => 'user_id' => '42' }).response
+page = ExamplePage.new(response: response)
+```
+
 ## Extending
 
 There are two main ways to extend `scraped` with your own custom logic - custom requests and decorated responses. Custom requests allow you to change where the scraper is getting its responses from, e.g. you might want to make requests to archive.org if the site you're scraping has disappeared. Decorated responses allow you to manipulate the response before it's passed to the scraper. Scraped comes with some [built in decorators](#built-in-decorators) for common tasks such as making all the link urls on the page absolute rather than relative.

--- a/lib/scraped/request.rb
+++ b/lib/scraped/request.rb
@@ -3,8 +3,9 @@ require 'scraped/response'
 
 module Scraped
   class Request
-    def initialize(url:, strategies: [Strategy::LiveRequest])
+    def initialize(url:, headers: {}, strategies: [Strategy::LiveRequest])
       @url = url
+      @headers = headers
       @strategies = strategies
     end
 
@@ -16,7 +17,7 @@ module Scraped
 
     private
 
-    attr_reader :url, :strategies
+    attr_reader :url, :headers, :strategies
 
     def first_successful_response
       @first_successful_response ||=
@@ -25,7 +26,7 @@ module Scraped
             strategy_config = { strategy: strategy_config }
           end
           strategy_class = strategy_config.delete(:strategy)
-          strategy_class.new(url: url, config: strategy_config).response
+          strategy_class.new(url: url, headers: headers, config: strategy_config).response
         end.reject(&:nil?).first
     end
   end

--- a/lib/scraped/request/strategy.rb
+++ b/lib/scraped/request/strategy.rb
@@ -3,8 +3,9 @@ module Scraped
     class Strategy
       class NotImplementedError < StandardError; end
 
-      def initialize(url:, config: {})
+      def initialize(url:, headers: {}, config: {})
         @url = url
+        @headers = headers
         @config = config.to_h
       end
 
@@ -14,7 +15,7 @@ module Scraped
 
       private
 
-      attr_reader :url, :config
+      attr_reader :url, :headers, :config
     end
   end
 end

--- a/lib/scraped/request/strategy/live_request.rb
+++ b/lib/scraped/request/strategy/live_request.rb
@@ -7,7 +7,7 @@ module Scraped
       class LiveRequest < Strategy
         def response
           log "Fetching #{url}"
-          response = open(url)
+          response = open(url, headers)
           {
             status:  response.status.first.to_i,
             headers: response.meta,

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
 module Scraped
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/test/scraped/request/strategy_test.rb
+++ b/test/scraped/request/strategy_test.rb
@@ -33,4 +33,26 @@ describe Scraped::Request::Strategy do
       end.must_raise Scraped::Request::Strategy::NotImplementedError
     end
   end
+
+  describe 'passing request headers' do
+    class TestHeadersStrategy < Scraped::Request::Strategy
+      def response
+        { body: "Status: #{headers['X-Testing-Status']}" }
+      end
+    end
+
+    let(:response) do
+      TestHeadersStrategy.new(
+        url:     'http://example.com',
+        headers: {
+          'X-Testing-Status' => 'Test successful',
+        },
+        config:  { name: 'Alice' }
+      ).response
+    end
+
+    it 'makes the headers available to the strategy' do
+      response[:body].must_equal 'Status: Test successful'
+    end
+  end
 end

--- a/test/scraped/request_test.rb
+++ b/test/scraped/request_test.rb
@@ -64,6 +64,26 @@ describe Scraped::Request do
         response.body.must_equal 'Success'
       end
     end
+
+    describe 'with request headers' do
+      class StrategyUsingHeaders < Scraped::Request::Strategy
+        def response
+          { body: "Name: #{headers['X-Test-Name']}" }
+        end
+      end
+
+      let(:response) do
+        Scraped::Request.new(
+          url:        'http://example.com',
+          headers:    { 'X-Test-Name' => 'Alice' },
+          strategies: [StrategyUsingHeaders]
+        ).response
+      end
+
+      it 'includes the header in the response' do
+        response.body.must_equal 'Name: Alice'
+      end
+    end
   end
 
   describe 'decorators' do


### PR DESCRIPTION
This adds a `headers:` argument to the `Scraped::Request.new`, allowing users to pass request headers without having to override the underlying strategy.

Fixes #75 