### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/lib/scraped.rb
+++ b/lib/scraped.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'require_all'
 require_rel 'scraped'
 

--- a/lib/scraped/document.rb
+++ b/lib/scraped/document.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'nokogiri'
 require 'field_serializer'
 

--- a/scraped.gemspec
+++ b/scraped.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'scraped/version'

--- a/test/scraped/html_test.rb
+++ b/test/scraped/html_test.rb
@@ -4,11 +4,11 @@ describe Scraped::HTML do
   describe 'accessing HTML via nokogiri' do
     let(:html) do
       <<-HTML
-<p class="test-content">Hi there!</p>
-<p class="name">Members Page</p>
-<div class="member-info">
-  <p class="name">Alice</p>
-</div>
+        <p class="test-content">Hi there!</p>
+        <p class="name">Members Page</p>
+        <div class="member-info">
+          <p class="name">Alice</p>
+        </div>
       HTML
     end
 


### PR DESCRIPTION
This fixes some new offenses reported by [Rubocop v0.48.0](https://github.com/bbatsov/rubocop/blob/d51c76fde7892ab65ab133098fcf6759c6f00400/CHANGELOG.md#0480-2017-03-26), which was released a couple of days ago.

Fixes #78 