### PR TITLE
Set up tests for VCR

### DIFF
--- a/scraped.gemspec
+++ b/scraped.gemspec
@@ -27,6 +27,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'minitest-around'
+  spec.add_development_dependency 'minitest-vcr'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rubocop', '~> 0.44'
+  spec.add_development_dependency 'webmock'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,12 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'scraped'
 
+require 'minitest/around/spec'
 require 'minitest/autorun'
+require 'vcr'
+require 'webmock'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'test/cassettes'
+  c.hook_into :webmock
+end


### PR DESCRIPTION
Set up to enable tests to be run against VCR cassettes. This will enable future tests to be run against live data.