### PR TITLE
Add Scraped::JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.6.0 - 2017-03-30
+
+### Added
+
+- Added `Scaped::JSON` to handle JSON documents.
+
 ## 0.5.1 - 2017-03-28
 
 ### Fixed

--- a/lib/scraped/json.rb
+++ b/lib/scraped/json.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Scraped
+  class JSON < Document
+    private
+
+    def initialize(json: nil, **args)
+      super(**args)
+      @json = json
+    end
+
+    def json
+      @json ||= ::JSON.parse(response.body, symbolize_names: true)
+    end
+
+    def fragment(mapping)
+      json_fragment, klass = mapping.to_a.first
+      klass.new(json: json_fragment, response: response)
+    end
+  end
+end

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
 module Scraped
-  VERSION = '0.5.1'.freeze
+  VERSION = '0.6.0'.freeze
 end

--- a/test/scraped/json_test.rb
+++ b/test/scraped/json_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+describe Scraped::JSON do
+  let(:json) do
+    <<-JSON
+      {
+        "test_content": "Hi there!",
+        "member_info": {
+          "name": "Alice"
+        }
+      }
+    JSON
+  end
+
+  let(:response) do
+    Scraped::Response.new(
+      body: json,
+      url:  'http://example.com'
+    )
+  end
+
+  class JSONMemberInfo < Scraped::JSON
+    field :name do
+      json[:name]
+    end
+  end
+
+  class JSONExamplePage < Scraped::JSON
+    field :content do
+      json[:test_content]
+    end
+
+    field :member do
+      fragment json[:member_info] => JSONMemberInfo
+    end
+  end
+
+  let(:page) { JSONExamplePage.new(response: response) }
+
+  it 'returns the expected content' do
+    page.content.must_equal 'Hi there!'
+  end
+
+  describe 'fragment method' do
+    let(:page) { JSONExamplePage.new(response: response) }
+
+    it 'returns content from a subset of the page' do
+      page.member.name.must_equal 'Alice'
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/everypolitician/scraped/issues/81

This PR adds a class that handles JSON documents.

```son
{
  "id": "123",
  "name": "Mike"
}
```

The json values are accessed via the json object. 

```ruby
require 'scraped'

class ExamplePage < Scraped::JSON
  field :id do
    json[:id]
  end

  field :name do
    json[:name]
  end
end
```