### PR TITLE
Fix CleanUrls reference in CHANGELOG for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- `Scraped::Response::Decorator::AbsoluteUrls` now handles all `URI::Error` exceptions. [#65](https://github.com/everypolitician/scraped/issues/65).
+- `Scraped::Response::Decorator::CleanUrls` now handles all `URI::Error` exceptions. [#65](https://github.com/everypolitician/scraped/issues/65).
 
 ## 0.5.0 - 2017-03-17
 


### PR DESCRIPTION
The changelog was written before AbsoluteUrls was renamed to CleanUrls. The change was actually made to CleanUrls, so fix the CHANGELOG to match reality.

Prompted by this comment - https://github.com/everypolitician/scraped/pull/70#issuecomment-290516760.

Closes #88 