### PR TITLE
change %i to use square bracket delimiters to satisfy Rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,4 @@ end
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task default: %i(test rubocop)
+task default: %i[test rubocop]


### PR DESCRIPTION
Latest Rubocop (v 0.48.1) expects `%i[ ... ]` not `%i( ... )`

Addresses #93 