### PR TITLE
Add deprecation warning for AbsoluteUrls class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.6.1 - 2017-04-13
+
+### Fixed
+
+- Output a warning when the user tries to use the deprecated `AbsoluteUrls` class, which was renamed to `CleanUrls` in 0.5.1.
+
 ## 0.6.0 - 2017-03-30
 
 ### Added

--- a/lib/scraped/response/decorator/clean_urls.rb
+++ b/lib/scraped/response/decorator/clean_urls.rb
@@ -40,6 +40,17 @@ module Scraped
           AbsoluteUrl.new(base_url: url, relative_url: relative_url).to_s
         end
       end
+
+      # The 'AbsoluteUrls' class was renamed to 'CleanUrls', so output a
+      # deprecation warning when a user tries to use it.
+      #
+      # Modified version of http://myronmars.to/n/dev-blog/2011/09/deprecating-constants-and-classes-in-ruby
+      def self.const_missing(const_name)
+        super unless const_name == :AbsoluteUrls
+        warn '`Scraped::Response::Decorator::AbsoluteUrls` has been deprecated. ' \
+          'Use `Scraped::Response::Decorator::CleanUrls` instead.'
+        CleanUrls
+      end
     end
   end
 end

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
 module Scraped
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.1'.freeze
 end

--- a/test/scraped/response/decorator/clean_urls_test.rb
+++ b/test/scraped/response/decorator/clean_urls_test.rb
@@ -143,4 +143,18 @@ describe Scraped::Response::Decorator::CleanUrls do
   it 'ignores invalid mailto links' do
     page.broken_mailto_link.must_equal 'mailto:notanemail'
   end
+
+  describe 'AbsoluteUrls' do
+    it 'returns CleanUrls' do
+      check_warning = lambda do |msg|
+        msg.must_equal '`Scraped::Response::Decorator::AbsoluteUrls` has been deprecated. ' \
+          'Use `Scraped::Response::Decorator::CleanUrls` instead.'
+        nil
+      end
+
+      Scraped::Response::Decorator.stub(:warn, check_warning) do
+        Scraped::Response::Decorator::AbsoluteUrls.must_equal Scraped::Response::Decorator::CleanUrls
+      end
+    end
+  end
 end

--- a/test/scraped/response/decorator/clean_urls_test.rb
+++ b/test/scraped/response/decorator/clean_urls_test.rb
@@ -145,16 +145,19 @@ describe Scraped::Response::Decorator::CleanUrls do
   end
 
   describe 'AbsoluteUrls' do
-    it 'returns CleanUrls' do
-      check_warning = lambda do |msg|
-        msg.must_equal '`Scraped::Response::Decorator::AbsoluteUrls` has been deprecated. ' \
-          'Use `Scraped::Response::Decorator::CleanUrls` instead.'
-        nil
+    it 'gives a deprecation warning' do
+      _out, err = capture_io do
+        klass = Class.new(Scraped::HTML) do
+          decorator Scraped::Response::Decorator::AbsoluteUrls
+
+          field :relative_image do
+            noko.at_css('.relative-image/@src').text
+          end
+        end
+        klass.new(response: response).relative_image.must_equal 'http://example.com/person-123.jpg'
       end
 
-      Scraped::Response::Decorator.stub(:warn, check_warning) do
-        Scraped::Response::Decorator::AbsoluteUrls.must_equal Scraped::Response::Decorator::CleanUrls
-      end
+      err.must_include 'has been deprecated'
     end
   end
 end


### PR DESCRIPTION
In #74 we renamed `AbsoluteUrls` to `CleanUrls`, but at the time we didn't deprecate the constant, we simply removed it. This adds a warning back in so that when a scraper uses the `AbsoluteUrls` decorator they will get a warning rather than things breaking for them.

```
$ bin/console 
[1] pry(main)> Scraped::Response::Decorator::AbsoluteUrls
`Scraped::Response::Decorator::AbsoluteUrls` has been deprecated. Use `Scraped::Response::Decorator::CleanUrls` instead.
=> Scraped::Response::Decorator::CleanUrls
```

Fixes https://github.com/everypolitician/scraped/issues/87