### PR TITLE
Gracefully handle broken URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.6.2 - 2017-08-08
+
+### Fixed
+
+- More gracefully recovers when CleanUurls encounters a URL it is unable to handle
+
 ## 0.6.1 - 2017-04-13
 
 ### Fixed

--- a/lib/scraped/response/decorator/clean_urls.rb
+++ b/lib/scraped/response/decorator/clean_urls.rb
@@ -18,7 +18,7 @@ module Scraped
                 URI.decode(relative_url)
               ).gsub('[', '%5B').gsub(']', '%5D')).to_s
             end
-          rescue URI::Error
+          rescue
             relative_url
           end
 

--- a/lib/scraped/version.rb
+++ b/lib/scraped/version.rb
@@ -1,3 +1,3 @@
 module Scraped
-  VERSION = '0.6.1'.freeze
+  VERSION = '0.6.2'.freeze
 end

--- a/test/scraped/response/decorator/clean_urls_test.rb
+++ b/test/scraped/response/decorator/clean_urls_test.rb
@@ -16,6 +16,7 @@ describe Scraped::Response::Decorator::CleanUrls do
     <a class="bracketed-link" href="/person[123]">Person 123</a>
     <a class="relative-link-with-unencoded-space" href="/person 123">Person 123</a>
     <a class="encoded-url" href="/person%20123">Person 123</a>
+    <a class="badly-encoded-url" href="http://cir.duma.gov.ru/servlet?QueryString=%2FGD_%C4%C5%CF%D3%D2+%C8.%CD.%22">Person 123</a>
     <a class="broken-mailto-link" href="mailto:notanemail">Person 123</a>
     BODY
   end
@@ -75,6 +76,10 @@ describe Scraped::Response::Decorator::CleanUrls do
 
     field :encoded_url do
       link('.encoded-url')
+    end
+
+    field :badly_encoded_url do
+      link('.badly-encoded-url')
     end
 
     field :broken_mailto_link do
@@ -138,6 +143,10 @@ describe Scraped::Response::Decorator::CleanUrls do
 
   it 'should not encode already encoded URLs' do
     page.encoded_url.must_equal 'http://example.com/person%20123'
+  end
+
+  it 'should gracefully cope with badly encoded URLs' do
+    page.badly_encoded_url.must_equal 'http://cir.duma.gov.ru/servlet?QueryString=%2FGD_%C4%C5%CF%D3%D2+%C8.%CD.%22'
   end
 
   it 'ignores invalid mailto links' do


### PR DESCRIPTION
If we try to clean up a URL that is so badly broken that URI blows up (e.g. if it is percent-encoded as something other than UTF-8), we should simply leave the original URL as-is, and move on, rather than generating a run-time error on something that the user may not even care about.

Fixes https://github.com/everypolitician/scraped/issues/99

It would also be good to log these problems in a way that is accessible to the scraper if required, but without producing lots of unwanted output otherwise. https://github.com/everypolitician/scraped/pull/54 is currently dealing with that.